### PR TITLE
Support Ids on entities

### DIFF
--- a/toys of toys/ecs3.nim
+++ b/toys of toys/ecs3.nim
@@ -1,0 +1,58 @@
+import ../yeacs
+import strutils
+
+type
+  UnitKind = enum
+    Soldier, Truck, Ship, Root
+
+  Unit = object
+    name: string
+    kind: UnitKind
+    position: int
+    children: seq[Id]
+
+proc makeSoldier(name: string, position: int): Unit =
+  Unit(kind: Soldier, position: position, name: name)
+
+proc makeTruck(name: string, position: int, children: seq[Id]): Unit =
+  Unit(kind: Truck, position: position, name: name, children: children)
+
+proc makeShip(name: string, position: int, children: seq[Id]): Unit =
+  Unit(kind: Ship, position: position, name: name, children: children)
+
+proc makeRoot(children: seq[Id]): Unit =
+  Unit(kind: Root, position: 0, name: "root", children: children)
+
+proc move(unit: var Unit, delta: int) =
+  unit.position += delta
+
+var world = World()
+
+proc show(world: var World, unit: Unit, depth: int = 0) =
+  echo "  ".repeat(depth), unit.name, ": ", unit.position
+  for child in unit.children:
+    let childEntity = world.getEntity(child)
+    for childUnit in world.component(childEntity, Unit):
+      world.show(childUnit, depth + 1)
+
+let abe = world.addEntity (Id(), makeSoldier("abe", 0))
+let ben = world.addEntity (Id(), makeSoldier("ben", 1))
+let bob = world.addEntity (Id(), makeSoldier("bob", 1))
+let dom = world.addEntity (Id(), makeSoldier("dom", 2))
+let ray = world.addEntity (Id(), makeSoldier("ray", 2))
+let rob = world.addEntity (Id(), makeSoldier("rob", 3))
+
+let truckA = world.addEntity (Id(), makeTruck("truck A", 0, @[abe.id, ben.id]))
+let truckB = world.addEntity (Id(), makeTruck("truck B", 5, @[bob.id, dom.id]))
+
+let ship = world.addEntity (Id(), makeShip("ship", 0, @[ray.id, truckA.id]))
+
+let root = world.addEntity (Id(), makeRoot(@[ship.id, truckB.id, rob.id]))
+
+echo $world
+
+for rootUnit in world.component(root, Unit):
+  world.show(rootUnit)
+
+echo "Id type info:   ", Id.getTheTypeInfo().int
+echo "Unit type info: ", Unit.getTheTypeInfo().int

--- a/toys of toys/ecs3.nim
+++ b/toys of toys/ecs3.nim
@@ -11,48 +11,66 @@ type
     position: int
     children: seq[Id]
 
-proc makeSoldier(name: string, position: int): Unit =
-  Unit(kind: Soldier, position: position, name: name)
+proc makeSoldier(name: string, position: int): (Id, Unit) =
+  (Id(), Unit(kind: Soldier, position: position, name: name))
 
-proc makeTruck(name: string, position: int, children: seq[Id]): Unit =
-  Unit(kind: Truck, position: position, name: name, children: children)
+proc makeTruck(name: string, position: int, children: seq[Id]): (Id, Unit) =
+  (Id(), Unit(kind: Truck, position: position, name: name, children: children))
 
-proc makeShip(name: string, position: int, children: seq[Id]): Unit =
-  Unit(kind: Ship, position: position, name: name, children: children)
+proc makeShip(name: string, position: int, children: seq[Id]): (Id, Unit) =
+  (Id(), Unit(kind: Ship, position: position, name: name, children: children))
 
-proc makeRoot(children: seq[Id]): Unit =
-  Unit(kind: Root, position: 0, name: "root", children: children)
+proc makeRoot(children: seq[Id]): (Id, Unit) =
+  (Id(), Unit(kind: Root, position: 0, name: "root", children: children))
 
 proc move(unit: var Unit, delta: int) =
   unit.position += delta
 
-var world = World()
-
-proc show(world: var World, unit: Unit, depth: int = 0) =
-  echo "  ".repeat(depth), unit.name, ": ", unit.position
+proc show(world: var World, unit: Unit, globalPosition: int = 0, depth: int = 0) =
+  let unitGlobalPosition = unit.position + globalPosition
+  echo "   ".repeat(depth), "[", unit.name, " local pos: ", unit.position, " global pos: ", unitGlobalPosition, " kind: ", unit.kind, "]"
   for child in unit.children:
     let childEntity = world.getEntity(child)
     for childUnit in world.component(childEntity, Unit):
-      world.show(childUnit, depth + 1)
+      world.show(childUnit, unitGlobalPosition, depth + 1)
 
-let abe = world.addEntity (Id(), makeSoldier("abe", 0))
-let ben = world.addEntity (Id(), makeSoldier("ben", 1))
-let bob = world.addEntity (Id(), makeSoldier("bob", 1))
-let dom = world.addEntity (Id(), makeSoldier("dom", 2))
-let ray = world.addEntity (Id(), makeSoldier("ray", 2))
-let rob = world.addEntity (Id(), makeSoldier("rob", 3))
+proc show(world: var World, root: Entity) =
+  for rootUnit in world.component(root, Unit):
+    world.show(rootUnit)
 
-let truckA = world.addEntity (Id(), makeTruck("truck A", 0, @[abe.id, ben.id]))
-let truckB = world.addEntity (Id(), makeTruck("truck B", 5, @[bob.id, dom.id]))
+var world = World()
 
-let ship = world.addEntity (Id(), makeShip("ship", 0, @[ray.id, truckA.id]))
+let abe = world.addEntity makeSoldier("abe", 0)
+let ben = world.addEntity makeSoldier("ben", 1)
+let bob = world.addEntity makeSoldier("bob", 1)
+let dom = world.addEntity makeSoldier("dom", 2)
+let ray = world.addEntity makeSoldier("ray", 2)
+let rob = world.addEntity makeSoldier("rob", 3)
 
-let root = world.addEntity (Id(), makeRoot(@[ship.id, truckB.id, rob.id]))
+let truckA = world.addEntity makeTruck("truck A", 0, @[abe.id, ben.id])
+let truckB = world.addEntity makeTruck("truck B", 5, @[bob.id, dom.id])
 
-echo $world
+let ship = world.addEntity makeShip("ship", 0, @[ray.id, truckA.id])
 
-for rootUnit in world.component(root, Unit):
-  world.show(rootUnit)
+let root = world.addEntity makeRoot(@[ship.id, truckB.id, rob.id])
 
-echo "Id type info:   ", Id.getTheTypeInfo().int
-echo "Unit type info: ", Unit.getTheTypeInfo().int
+echo "\nInitial state:"
+world.show(root)
+
+echo "\nTruck A moves 2 units:"
+for unit in world.component(truckA, Unit):
+  unit.move(2)
+
+world.show(root)
+
+echo "\nShip moves 4 units:"
+for unit in world.component(ship, Unit):
+  unit.move(4)
+
+world.show(root)
+
+echo "\nRob moves 5 units:"
+for unit in world.component(rob, Unit):
+  unit.move(5)
+
+world.show(root)


### PR DESCRIPTION
**What**
Adds the `Id` concept to entities.
- Fixes a few bugs in the `component` and `components` iterators
- Adds an `Id` component which contains only an opaque index within the `entityPointers` seq
- When adding an entity, if an Id component is present, it is set to the index in the `entityPointers` seq
- Adds a `getEntity` method which takes an `Id` and returns the `Entity`
- Renames `entIndex` to `entArchIndex`, since it is an index into the archetype it belongs to
- Adds a usage example in `toys of toys/ecs3.nim`

**Why**
To allow **yeacs** to build hierarchies. While just adding an `Entity` reference to any component would be more than enough to build a hierarchy, doing so using `Id`s allows serializing the world state in the future.